### PR TITLE
fix(QUI-51): use 30-second restart interval to prevent restart limits

### DIFF
--- a/pkg/deb/service
+++ b/pkg/deb/service
@@ -7,6 +7,7 @@ Environment=QUIBLE_DATABASE_URL=ws://localhost:8000
 Environment=QUIBLE_SIGNER_KEY_FILE=/etc/quible-signer-key
 Environment=QUIBLE_LEADER_MULTIADDR=/dns4/testnet-rpc.quible.network/tcp/9014
 Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Systemd by default will stop restarting a service if it restarts too
quickly. By increasing the restart interval, we can prevent the service
from triggering the limit, which allows it to continue restarting until
it stays up.

Closes QUI-51