### PR TITLE
feat(QUI-102): ensure transactions can spend outputs from previous blocks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ impl ExecutionContext for QuibleBlockProposerExecutionContextImpl {
         let transaction_hash_hex = hex::encode(outpoint.txid);
         let mut result = self
             .db
-            .query("SELECT * FROM pending_transactions WHERE id = $id")
+            .query("SELECT * FROM transaction_outputs WHERE id = $id")
             .bind((
                 "id",
                 SurrealID(Thing::from((

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,18 +256,18 @@ async fn propose_block(
                     spent: false,
                 })
                 .await?;
+        }
 
-            db_arc
-                .query("DELETE FROM pending_transactions WHERE id = $id")
-                .bind((
+        db_arc
+            .query("DELETE FROM pending_transactions WHERE id = $id")
+            .bind((
                     "id",
                     SurrealID(Thing::from((
-                        "pending_transactions".to_string(),
-                        transaction_hash_hex.clone().to_string(),
+                                "pending_transactions".to_string(),
+                                transaction_hash_hex.clone().to_string(),
                     ))),
-                ))
-                .await?;
-        }
+            ))
+            .await?;
     }
 
     Ok(block_row)

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,11 +261,11 @@ async fn propose_block(
         db_arc
             .query("DELETE FROM pending_transactions WHERE id = $id")
             .bind((
-                    "id",
-                    SurrealID(Thing::from((
-                                "pending_transactions".to_string(),
-                                transaction_hash_hex.clone().to_string(),
-                    ))),
+                "id",
+                SurrealID(Thing::from((
+                    "pending_transactions".to_string(),
+                    transaction_hash_hex.clone().to_string(),
+                ))),
             ))
             .await?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,8 @@ async fn propose_block(
         inputs: vec![],
         outputs: vec![TransactionOutput::Value {
             value: 5,
+
+            // TODO: https://linear.app/quible/issue/QUI-103/ensure-coinbase-transactions-can-only-be-spent-by-block-proposer
             pubkey_script: vec![],
         }],
         locktime: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,7 @@ async fn propose_block(block_number: u64, db_arc: &Arc<Surreal<AnyDb>>) {
 }
 pub struct QuibleRpcServerImpl {
     db: Arc<Surreal<AnyDb>>,
-    node_signer_key: [u8; 32],
+    // node_signer_key: [u8; 32],
 }
 
 #[jsonrpsee_async_trait]
@@ -328,7 +328,7 @@ impl rpc::QuibleRpcServer for QuibleRpcServerImpl {
 }
 
 async fn run_derive_server(
-    node_signer_key: [u8; 32],
+    _node_signer_key: [u8; 32],
     db: &Arc<Surreal<AnyDb>>,
     port: u16,
 ) -> anyhow::Result<SocketAddr> {
@@ -349,7 +349,7 @@ async fn run_derive_server(
     let handle = server.start(
         QuibleRpcServerImpl {
             db: db.clone(),
-            node_signer_key,
+            // node_signer_key,
         }
         .into_rpc(),
     );


### PR DESCRIPTION
fix(execution context): use correct table name for transaction_outputs

tweak(main): hide some dead code

refactor(main): return block rows from propose_block function

feat(block proposer): insert coinbase transactions during block proposals

test(main): transactions can spend outputs from previous blocks